### PR TITLE
Update plugin.json to match project readme

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -33,7 +33,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": "7.3.x",
+    "grafanaDependency": ">=7.3.x",
     "plugins": []
   }
 }


### PR DESCRIPTION
Hi there 👋 

I noticed some oddities occurring where the latest version of your plugin wasn't being installed.

Given the statement in your readme:
> Grafana version 7.3.x or above are supported

I believe this should be the setting for `grafanaDependency`

Setting at `7.3.x` means it will only work on 7.3.x versions of Grafana.

Thanks for your contribution 🙌 

